### PR TITLE
Mark intensity snuggets as html safe

### DIFF
--- a/disasterinfosite/templates/snugget_text.html
+++ b/disasterinfosite/templates/snugget_text.html
@@ -9,7 +9,7 @@
         {% endif %}
       </div>
       <div class="intensity-content">
-        <p>{{ snugget.content }}</p>
+        <p>{{ snugget.content | safe }}</p>
       </div>
     </div>
     {% else %}


### PR DESCRIPTION
I had forgotten that I'd special-cased the intensity snuggets.
