### PR TITLE
Remove lazy loading entirely

### DIFF
--- a/disasterinfosite/static/js/app.js
+++ b/disasterinfosite/static/js/app.js
@@ -146,7 +146,6 @@ $( document ).ready(function() {
     var currentSlideElement = $('.disaster-content.active .past-photos');
     currentSlideElement.slick({
       slidesToShow: 1,
-      lazyLoad: 'progressive',
       variableWidth: true,
       prevArrow: '<button type="button" class="slick-prev"><</button>',
       nextArrow: '<button type="button" class="slick-next">></button>'

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -54,7 +54,7 @@
                   <h3>Photos of Past Events</h3>
                   <div class="past-photos">
                     {% for photo in hazard.photos %}
-                     <img alt="A historical image of {{ hazard.heading }} in {{ location.areaname }}" class="slideshow-image" data-lazy="{{ photo }}"/>
+                     <img alt="A historical image of {{ hazard.heading }} in {{ location.areaname }}" class="slideshow-image" src="{{ photo }}"/>
                     {% endfor %}
                   </div>
                 {% endif %}


### PR DESCRIPTION
I was seeing a jitter in the area around the slideshow when I reloaded the page. Sadly, I think that taking lazy loading out is the solution here.
