### PR TITLE
Make things more configurable/less hardcoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,46 @@ Note that the `python manage.py makemigrations` step will probably tell you ther
 
 # Values to put in Django Admin
 
-### Tab and Section orders
+### Tabs
+
+######Fire
+    Display Name: Wildfire
+    Order: 0
+    Likely Scenario Title: Likely Wildfire Scenario
+    Likely Scenario Text: Wildfire season stretches from spring to fall in Missoula County. In a low snowpack year the potential for fires increases. Is the area where you live at risk for a potential burn?
+
+######Flooding
+    Display Name: Flooding
+    Order: 1
+    Likely Scenario Title: Likely Flood Scenario
+    Likely Scenario Text: It’s springtime in Missoula County and the temperature has been steadily rising causing the snowpack to melt. It has been raining for many days and the rivers begin flooding. Will you feel the flood effects?
+
+######Winter Weather
+    Display Name: Winter Weather
+    Order: 2
+    Likely Scenario Title: Likely Winter Storm Scenario
+    Likely Scenario Text: In the wintertime in Missoula County you can expect to see low temperatures, inches to feet of snow, and inversions causing poor air quality in the valleys. This can stretch from October to May depending on the year. Go get some good winter boots and bundle up! What might your winter look like?
+
+######Summer Weather
+    Display Name: Summer Weather
+    Order: 3
+    Likely Scenario Title: Likely Summer Storm Scenario
+    Likely Scenario Text: In the summertime temperatures rise in Missoula County, sometimes into the 100s! There is potential for thunderstorms, high winds, and heat waves.  Besides planning your summer adventures, what should you prepare for?
+
+######Earthquake
+    Display Name: Earthquake
+    Order: 4
+    Likely Scenario Title: Earthquake
+    Likely Scenario Text: Earthquakes can happen anytime. In Missoula County there are five faults that are considered active. It is most likely that a small earthquake of magnitude 4 to 5 would strike here. What kind of shaking might you experience?
+
+######Landslide:
+    Display Name: Landslide
+    Order: 5
+    Likely Scenario Title: Landslide
+    Likely Scenario Text: Landslides typically happen after rainstorms come through and especially in burned areas without vegetation to stabilize the slopes. Find out if you should be concerned in your area.
+
+
+### Section orders
 
 ###### Snugget Section
 What to expect: 0

--- a/disasterinfosite/admin.py
+++ b/disasterinfosite/admin.py
@@ -7,13 +7,14 @@ from django.contrib.auth.models import User
 # GENERATED CODE GOES HERE
 # DO NOT MANUALLY EDIT CODE IN THIS SECTION - IT WILL BE OVERWRITTEN
 # adminModelImports
-from .models import EmbedSnugget, TextSnugget, SnuggetSection, SnuggetSubSection, Location, SiteSettings, SupplyKit, ImportantLink, Fire_Burn_Probability2, Flood_Worst_Case, EQ_Fault_Buffer, Fire_Worst_Case_ph2, EQ_Fault_Worst, EQ_Historic_Distance, EQ_Fault_Shaking, Flood_FEMA_DFRIM_2015, Fire_Hist_Bound, winterstorm, summerstorm, Landslide_placeholder2, Flood_Channel_Migration_Zones
+from .models import EmbedSnugget, TextSnugget, SnuggetSection, SnuggetSubSection, Location, SiteSettings, SupplyKit, ImportantLink, EQ_Fault_Buffer, EQ_Fault_Shaking, EQ_Fault_Worst, EQ_Historic_Distance, Fire_Burn_Probability2, Fire_Hist_Bound, Fire_Worst_Case_ph2, Flood_Channel_Migration_Zones, Flood_FEMA_DFRIM_2015, Flood_Worst_Case, Landslide_placeholder2, summerstorm, winterstorm
 # END OF GENERATED CODE BLOCK
 ######################################################
-from .models import PastEventsPhoto, DataOverviewImage, UserProfile
+from .models import PastEventsPhoto, DataOverviewImage, UserProfile, ShapefileGroup
 from .actions import export_as_csv_action
 admin.site.register(SnuggetSection, admin.ModelAdmin)
 admin.site.register(SnuggetSubSection, admin.ModelAdmin)
+admin.site.register(ShapefileGroup, admin.ModelAdmin)
 
 
 class SnuggetAdmin(admin.ModelAdmin):
@@ -21,8 +22,8 @@ class SnuggetAdmin(admin.ModelAdmin):
 # GENERATED CODE GOES HERE
 # DO NOT MANUALLY EDIT CODE IN THIS SECTION - IT WILL BE OVERWRITTEN
 # adminLists
-    list_display = ('shortname', 'section', 'sub_section', 'Fire_Burn_Probability2_filter', 'Flood_Worst_Case_filter', 'EQ_Fault_Buffer_filter', 'Fire_Worst_Case_ph2_filter', 'EQ_Fault_Worst_filter', 'EQ_Historic_Distance_filter', 'EQ_Fault_Shaking_filter', 'Flood_FEMA_DFRIM_2015_filter', 'Fire_Hist_Bound_filter', 'winterstorm_filter', 'summerstorm_filter', 'Landslide_placeholder2_filter', 'Flood_Channel_Migration_Zones_filter')
-    list_filter = ('section', 'sub_section', 'Fire_Burn_Probability2_filter', 'Flood_Worst_Case_filter', 'EQ_Fault_Buffer_filter', 'Fire_Worst_Case_ph2_filter', 'EQ_Fault_Worst_filter', 'EQ_Historic_Distance_filter', 'EQ_Fault_Shaking_filter', 'Flood_FEMA_DFRIM_2015_filter', 'Fire_Hist_Bound_filter', 'winterstorm_filter', 'summerstorm_filter', 'Landslide_placeholder2_filter', 'Flood_Channel_Migration_Zones_filter')
+    list_display = ('shortname', 'section', 'sub_section', 'EQ_Fault_Buffer_filter', 'EQ_Fault_Shaking_filter', 'EQ_Fault_Worst_filter', 'EQ_Historic_Distance_filter', 'Fire_Burn_Probability2_filter', 'Fire_Hist_Bound_filter', 'Fire_Worst_Case_ph2_filter', 'Flood_Channel_Migration_Zones_filter', 'Flood_FEMA_DFRIM_2015_filter', 'Flood_Worst_Case_filter', 'Landslide_placeholder2_filter', 'summerstorm_filter', 'winterstorm_filter')
+    list_filter = ('section', 'sub_section', 'EQ_Fault_Buffer_filter', 'EQ_Fault_Shaking_filter', 'EQ_Fault_Worst_filter', 'EQ_Historic_Distance_filter', 'Fire_Burn_Probability2_filter', 'Fire_Hist_Bound_filter', 'Fire_Worst_Case_ph2_filter', 'Flood_Channel_Migration_Zones_filter', 'Flood_FEMA_DFRIM_2015_filter', 'Flood_Worst_Case_filter', 'Landslide_placeholder2_filter', 'summerstorm_filter', 'winterstorm_filter')
 
     fieldsets = (
         (None, {
@@ -30,7 +31,7 @@ class SnuggetAdmin(admin.ModelAdmin):
         }),
         ('Filters', {
             'description': 'Choose a filter value this snugget will show up for.  It is recommended you only select a value for one filter and leave the rest empty.',
-            'fields': (('Fire_Burn_Probability2_filter', 'Flood_Worst_Case_filter', 'EQ_Fault_Buffer_filter', 'Fire_Worst_Case_ph2_filter', 'EQ_Fault_Worst_filter', 'EQ_Historic_Distance_filter', 'EQ_Fault_Shaking_filter', 'Flood_FEMA_DFRIM_2015_filter', 'Fire_Hist_Bound_filter', 'winterstorm_filter', 'summerstorm_filter', 'Landslide_placeholder2_filter', 'Flood_Channel_Migration_Zones_filter'))
+            'fields': (('EQ_Fault_Buffer_filter', 'EQ_Fault_Shaking_filter', 'EQ_Fault_Worst_filter', 'EQ_Historic_Distance_filter', 'Fire_Burn_Probability2_filter', 'Fire_Hist_Bound_filter', 'Fire_Worst_Case_ph2_filter', 'Flood_Channel_Migration_Zones_filter', 'Flood_FEMA_DFRIM_2015_filter', 'Flood_Worst_Case_filter', 'Landslide_placeholder2_filter', 'summerstorm_filter', 'winterstorm_filter'))
         })
     )
 # END OF GENERATED CODE BLOCK
@@ -91,19 +92,19 @@ admin.site.register(User, UserAdmin)
 # GENERATED CODE GOES HERE
 # DO NOT MANUALLY EDIT CODE IN THIS SECTION - IT WILL BE OVERWRITTEN
 # adminSiteRegistrations
-admin.site.register(Fire_Burn_Probability2, GeoNoEditAdmin)
-admin.site.register(Flood_Worst_Case, GeoNoEditAdmin)
 admin.site.register(EQ_Fault_Buffer, GeoNoEditAdmin)
-admin.site.register(Fire_Worst_Case_ph2, GeoNoEditAdmin)
+admin.site.register(EQ_Fault_Shaking, GeoNoEditAdmin)
 admin.site.register(EQ_Fault_Worst, GeoNoEditAdmin)
 admin.site.register(EQ_Historic_Distance, GeoNoEditAdmin)
-admin.site.register(EQ_Fault_Shaking, GeoNoEditAdmin)
-admin.site.register(Flood_FEMA_DFRIM_2015, GeoNoEditAdmin)
+admin.site.register(Fire_Burn_Probability2, GeoNoEditAdmin)
 admin.site.register(Fire_Hist_Bound, GeoNoEditAdmin)
-admin.site.register(winterstorm, GeoNoEditAdmin)
-admin.site.register(summerstorm, GeoNoEditAdmin)
-admin.site.register(Landslide_placeholder2, GeoNoEditAdmin)
+admin.site.register(Fire_Worst_Case_ph2, GeoNoEditAdmin)
 admin.site.register(Flood_Channel_Migration_Zones, GeoNoEditAdmin)
+admin.site.register(Flood_FEMA_DFRIM_2015, GeoNoEditAdmin)
+admin.site.register(Flood_Worst_Case, GeoNoEditAdmin)
+admin.site.register(Landslide_placeholder2, GeoNoEditAdmin)
+admin.site.register(summerstorm, GeoNoEditAdmin)
+admin.site.register(winterstorm, GeoNoEditAdmin)
 # END OF GENERATED CODE BLOCK
 ######################################################
 

--- a/disasterinfosite/load.py
+++ b/disasterinfosite/load.py
@@ -97,9 +97,9 @@ def run(verbose=True):
 
 # loadGroups
     from .models import ShapefileGroup
-    foo = ShapefileGroup.objects.get_or_create(name='foo')
-    bar = ShapefileGroup.objects.get_or_create(name='bar')
-    baz = ShapefileGroup.objects.get_or_create(name='baz')
+    q = ShapefileGroup.objects.get_or_create(name='q')
+    f = ShapefileGroup.objects.get_or_create(name='f')
+    w = ShapefileGroup.objects.get_or_create(name='w')
     Landslide_placeholder2 = ShapefileGroup.objects.get_or_create(name='Landslide_placeholder2')
     summerstorm = ShapefileGroup.objects.get_or_create(name='summerstorm')
     winterstorm = ShapefileGroup.objects.get_or_create(name='winterstorm')

--- a/disasterinfosite/load.py
+++ b/disasterinfosite/load.py
@@ -6,22 +6,12 @@ from django.contrib.gis.utils import LayerMapping
 # GENERATED CODE GOES HERE
 # DO NOT MANUALLY EDIT CODE IN THIS SECTION - IT WILL BE OVERWRITTEN
 # loadMappings
-Fire_Burn_Probability2_mapping = {
-    'lookup_val': 'lookup_val',
-    'geom': 'MULTIPOLYGON'
-}
-
-Flood_Worst_Case_mapping = {
-    'lookup_val': 'lookup_val',
-    'geom': 'MULTIPOLYGON'
-}
-
 EQ_Fault_Buffer_mapping = {
     'lookup_val': 'lookup_val',
     'geom': 'MULTIPOLYGON'
 }
 
-Fire_Worst_Case_ph2_mapping = {
+EQ_Fault_Shaking_mapping = {
     'lookup_val': 'lookup_val',
     'geom': 'MULTIPOLYGON'
 }
@@ -36,12 +26,7 @@ EQ_Historic_Distance_mapping = {
     'geom': 'MULTIPOLYGON'
 }
 
-EQ_Fault_Shaking_mapping = {
-    'lookup_val': 'lookup_val',
-    'geom': 'MULTIPOLYGON'
-}
-
-Flood_FEMA_DFRIM_2015_mapping = {
+Fire_Burn_Probability2_mapping = {
     'lookup_val': 'lookup_val',
     'geom': 'MULTIPOLYGON'
 }
@@ -51,17 +36,7 @@ Fire_Hist_Bound_mapping = {
     'geom': 'MULTIPOLYGON'
 }
 
-winterstorm_mapping = {
-    'lookup_val': 'lookup_val',
-    'geom': 'MULTIPOLYGON'
-}
-
-summerstorm_mapping = {
-    'lookup_val': 'lookup_val',
-    'geom': 'MULTIPOLYGON'
-}
-
-Landslide_placeholder2_mapping = {
+Fire_Worst_Case_ph2_mapping = {
     'lookup_val': 'lookup_val',
     'geom': 'MULTIPOLYGON'
 }
@@ -71,20 +46,45 @@ Flood_Channel_Migration_Zones_mapping = {
     'geom': 'MULTIPOLYGON'
 }
 
+Flood_FEMA_DFRIM_2015_mapping = {
+    'lookup_val': 'lookup_val',
+    'geom': 'MULTIPOLYGON'
+}
 
-Fire_Burn_Probability2_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Fire_Burn_Probability2.shp'))
-Flood_Worst_Case_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Flood_Worst_Case.shp'))
+Flood_Worst_Case_mapping = {
+    'lookup_val': 'lookup_val',
+    'geom': 'MULTIPOLYGON'
+}
+
+Landslide_placeholder2_mapping = {
+    'lookup_val': 'lookup_val',
+    'geom': 'MULTIPOLYGON'
+}
+
+summerstorm_mapping = {
+    'lookup_val': 'lookup_val',
+    'geom': 'MULTIPOLYGON'
+}
+
+winterstorm_mapping = {
+    'lookup_val': 'lookup_val',
+    'geom': 'MULTIPOLYGON'
+}
+
+
 EQ_Fault_Buffer_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/EQ_Fault_Buffer.shp'))
-Fire_Worst_Case_ph2_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Fire_Worst_Case_ph2.shp'))
+EQ_Fault_Shaking_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/EQ_Fault_Shaking.shp'))
 EQ_Fault_Worst_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/EQ_Fault_Worst.shp'))
 EQ_Historic_Distance_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/EQ_Historic_Distance.shp'))
-EQ_Fault_Shaking_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/EQ_Fault_Shaking.shp'))
-Flood_FEMA_DFRIM_2015_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Flood_FEMA_DFRIM_2015.shp'))
+Fire_Burn_Probability2_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Fire_Burn_Probability2.shp'))
 Fire_Hist_Bound_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Fire_Hist_Bound.shp'))
-winterstorm_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/winterstorm.shp'))
-summerstorm_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/summerstorm.shp'))
-Landslide_placeholder2_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Landslide_placeholder2.shp'))
+Fire_Worst_Case_ph2_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Fire_Worst_Case_ph2.shp'))
 Flood_Channel_Migration_Zones_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Flood_Channel_Migration_Zones.shp'))
+Flood_FEMA_DFRIM_2015_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Flood_FEMA_DFRIM_2015.shp'))
+Flood_Worst_Case_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Flood_Worst_Case.shp'))
+Landslide_placeholder2_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/Landslide_placeholder2.shp'))
+summerstorm_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/summerstorm.shp'))
+winterstorm_shp = os.path.abspath(os.path.join(os.path.dirname(__file__), '../disasterinfosite/data/simplified/winterstorm.shp'))
 # END OF GENERATED CODE BLOCK
 ######################################################
 
@@ -94,22 +94,30 @@ def run(verbose=True):
 ######################################################
 # GENERATED CODE GOES HERE
 # DO NOT MANUALLY EDIT CODE IN THIS SECTION - IT WILL BE OVERWRITTEN
+
+# loadGroups
+    from .models import ShapefileGroup
+    foo = ShapefileGroup.objects.get_or_create(name='foo')
+    bar = ShapefileGroup.objects.get_or_create(name='bar')
+    baz = ShapefileGroup.objects.get_or_create(name='baz')
+    Landslide_placeholder2 = ShapefileGroup.objects.get_or_create(name='Landslide_placeholder2')
+    summerstorm = ShapefileGroup.objects.get_or_create(name='summerstorm')
+    winterstorm = ShapefileGroup.objects.get_or_create(name='winterstorm')
+# END OF GENERATED CODE BLOCK
+######################################################
+
+######################################################
+# GENERATED CODE GOES HERE
+# DO NOT MANUALLY EDIT CODE IN THIS SECTION - IT WILL BE OVERWRITTEN
+
 # loadImports
-    from .models import Fire_Burn_Probability2
-    lm_Fire_Burn_Probability2 = LayerMapping(Fire_Burn_Probability2, Fire_Burn_Probability2_shp, Fire_Burn_Probability2_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
-    lm_Fire_Burn_Probability2.save(strict=True, verbose=verbose)
-
-    from .models import Flood_Worst_Case
-    lm_Flood_Worst_Case = LayerMapping(Flood_Worst_Case, Flood_Worst_Case_shp, Flood_Worst_Case_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
-    lm_Flood_Worst_Case.save(strict=True, verbose=verbose)
-
     from .models import EQ_Fault_Buffer
     lm_EQ_Fault_Buffer = LayerMapping(EQ_Fault_Buffer, EQ_Fault_Buffer_shp, EQ_Fault_Buffer_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
     lm_EQ_Fault_Buffer.save(strict=True, verbose=verbose)
 
-    from .models import Fire_Worst_Case_ph2
-    lm_Fire_Worst_Case_ph2 = LayerMapping(Fire_Worst_Case_ph2, Fire_Worst_Case_ph2_shp, Fire_Worst_Case_ph2_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
-    lm_Fire_Worst_Case_ph2.save(strict=True, verbose=verbose)
+    from .models import EQ_Fault_Shaking
+    lm_EQ_Fault_Shaking = LayerMapping(EQ_Fault_Shaking, EQ_Fault_Shaking_shp, EQ_Fault_Shaking_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
+    lm_EQ_Fault_Shaking.save(strict=True, verbose=verbose)
 
     from .models import EQ_Fault_Worst
     lm_EQ_Fault_Worst = LayerMapping(EQ_Fault_Worst, EQ_Fault_Worst_shp, EQ_Fault_Worst_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
@@ -119,33 +127,41 @@ def run(verbose=True):
     lm_EQ_Historic_Distance = LayerMapping(EQ_Historic_Distance, EQ_Historic_Distance_shp, EQ_Historic_Distance_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
     lm_EQ_Historic_Distance.save(strict=True, verbose=verbose)
 
-    from .models import EQ_Fault_Shaking
-    lm_EQ_Fault_Shaking = LayerMapping(EQ_Fault_Shaking, EQ_Fault_Shaking_shp, EQ_Fault_Shaking_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
-    lm_EQ_Fault_Shaking.save(strict=True, verbose=verbose)
-
-    from .models import Flood_FEMA_DFRIM_2015
-    lm_Flood_FEMA_DFRIM_2015 = LayerMapping(Flood_FEMA_DFRIM_2015, Flood_FEMA_DFRIM_2015_shp, Flood_FEMA_DFRIM_2015_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
-    lm_Flood_FEMA_DFRIM_2015.save(strict=True, verbose=verbose)
+    from .models import Fire_Burn_Probability2
+    lm_Fire_Burn_Probability2 = LayerMapping(Fire_Burn_Probability2, Fire_Burn_Probability2_shp, Fire_Burn_Probability2_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
+    lm_Fire_Burn_Probability2.save(strict=True, verbose=verbose)
 
     from .models import Fire_Hist_Bound
     lm_Fire_Hist_Bound = LayerMapping(Fire_Hist_Bound, Fire_Hist_Bound_shp, Fire_Hist_Bound_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
     lm_Fire_Hist_Bound.save(strict=True, verbose=verbose)
 
-    from .models import winterstorm
-    lm_winterstorm = LayerMapping(winterstorm, winterstorm_shp, winterstorm_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
-    lm_winterstorm.save(strict=True, verbose=verbose)
+    from .models import Fire_Worst_Case_ph2
+    lm_Fire_Worst_Case_ph2 = LayerMapping(Fire_Worst_Case_ph2, Fire_Worst_Case_ph2_shp, Fire_Worst_Case_ph2_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
+    lm_Fire_Worst_Case_ph2.save(strict=True, verbose=verbose)
 
-    from .models import summerstorm
-    lm_summerstorm = LayerMapping(summerstorm, summerstorm_shp, summerstorm_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
-    lm_summerstorm.save(strict=True, verbose=verbose)
+    from .models import Flood_Channel_Migration_Zones
+    lm_Flood_Channel_Migration_Zones = LayerMapping(Flood_Channel_Migration_Zones, Flood_Channel_Migration_Zones_shp, Flood_Channel_Migration_Zones_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
+    lm_Flood_Channel_Migration_Zones.save(strict=True, verbose=verbose)
+
+    from .models import Flood_FEMA_DFRIM_2015
+    lm_Flood_FEMA_DFRIM_2015 = LayerMapping(Flood_FEMA_DFRIM_2015, Flood_FEMA_DFRIM_2015_shp, Flood_FEMA_DFRIM_2015_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
+    lm_Flood_FEMA_DFRIM_2015.save(strict=True, verbose=verbose)
+
+    from .models import Flood_Worst_Case
+    lm_Flood_Worst_Case = LayerMapping(Flood_Worst_Case, Flood_Worst_Case_shp, Flood_Worst_Case_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
+    lm_Flood_Worst_Case.save(strict=True, verbose=verbose)
 
     from .models import Landslide_placeholder2
     lm_Landslide_placeholder2 = LayerMapping(Landslide_placeholder2, Landslide_placeholder2_shp, Landslide_placeholder2_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
     lm_Landslide_placeholder2.save(strict=True, verbose=verbose)
 
-    from .models import Flood_Channel_Migration_Zones
-    lm_Flood_Channel_Migration_Zones = LayerMapping(Flood_Channel_Migration_Zones, Flood_Channel_Migration_Zones_shp, Flood_Channel_Migration_Zones_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
-    lm_Flood_Channel_Migration_Zones.save(strict=True, verbose=verbose)
+    from .models import summerstorm
+    lm_summerstorm = LayerMapping(summerstorm, summerstorm_shp, summerstorm_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
+    lm_summerstorm.save(strict=True, verbose=verbose)
+
+    from .models import winterstorm
+    lm_winterstorm = LayerMapping(winterstorm, winterstorm_shp, winterstorm_mapping, transform=True, encoding='UTF-8', unique=['lookup_val'])
+    lm_winterstorm.save(strict=True, verbose=verbose)
 
 # END OF GENERATED CODE BLOCK
 ######################################################

--- a/disasterinfosite/migrations/0001_initial.py
+++ b/disasterinfosite/migrations/0001_initial.py
@@ -150,7 +150,6 @@ class Migration(migrations.Migration):
             fields=[
                 ('snugget_ptr', models.OneToOneField(auto_created=True, to='disasterinfosite.Snugget', serialize=False, primary_key=True, parent_link=True)),
                 ('content', models.TextField()),
-                ('heading', models.TextField(default="")),
                 ('image', models.TextField(default="")),
                 ('percentage', models.FloatField(null=True)),
             ],

--- a/disasterinfosite/migrations/0001_initial.py
+++ b/disasterinfosite/migrations/0001_initial.py
@@ -102,6 +102,17 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
+            name='ShapefileGroup',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, primary_key=True, auto_created=True)),
+                ('name', models.CharField(max_length=50)),
+                ('display_name', models.CharField(max_length=50)),
+                ('order_of_appearance', models.IntegerField(help_text='The order, from left to right, in which you would like this group to appear, when applicable.', default=0)),
+                ('likely_scenario_title', models.CharField(max_length=80)),
+                ('likely_scenario_text', models.TextField()),
+            ],
+        ),
+        migrations.CreateModel(
             name='SnuggetType',
             fields=[
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
@@ -114,7 +125,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('name', models.CharField(max_length=50)),
-                ('order', models.IntegerField(default=0, help_text="The order in which you'd like this to appear in the tab. 0 is at the top."))
+                ('order_of_appearance', models.IntegerField(default=0, help_text="The order in which you'd like this to appear in the tab. 0 is at the top."))
             ],
         ),
         migrations.CreateModel(
@@ -122,7 +133,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('name', models.CharField(max_length=50)),
-                ('order', models.IntegerField(default=0, help_text="The order in which you'd like this to appear in the section. 0 is at the top. These can be in different sections or mutually exclusive, hence the non-unique values."))
+                ('order_of_appearance', models.IntegerField(default=0, help_text="The order in which you'd like this to appear in the section. 0 is at the top. These can be in different sections or mutually exclusive, hence the non-unique values."))
             ],
         ),
         migrations.CreateModel(
@@ -131,6 +142,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('section', models.ForeignKey(to='disasterinfosite.SnuggetSection', on_delete=django.db.models.deletion.PROTECT, related_name='+')),
                 ('sub_section', models.ForeignKey(to='disasterinfosite.SnuggetSubSection', on_delete=django.db.models.deletion.PROTECT, related_name='+', blank=True, null=True)),
+                ('group', models.ForeignKey(to='disasterinfosite.ShapefileGroup', null='True', on_delete=django.db.models.deletion.PROTECT))
             ],
         ),
         migrations.CreateModel(
@@ -156,7 +168,7 @@ class Migration(migrations.Migration):
             name='PastEventsPhoto',
             fields=[
                 ('id', models.AutoField(primary_key=True, serialize=False, verbose_name='ID', auto_created=True)),
-                ('heading', models.CharField(default='', max_length=50)),
+                ('group', models.ForeignKey(to='disasterinfosite.ShapefileGroup', null=True, on_delete=django.db.models.deletion.PROTECT)),
                 ('image', models.ImageField(upload_to='photos')),
             ],
         ),
@@ -189,6 +201,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.IntegerField()),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -197,6 +210,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.IntegerField()),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -205,6 +219,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.IntegerField()),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -213,6 +228,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.IntegerField()),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -221,6 +237,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.IntegerField()),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -229,6 +246,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.IntegerField()),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -237,6 +255,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.IntegerField()),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -245,6 +264,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.CharField(max_length=80)),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -253,6 +273,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.CharField(max_length=80)),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -261,6 +282,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.IntegerField()),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -269,6 +291,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.FloatField()),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -277,6 +300,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.IntegerField()),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.CreateModel(
@@ -285,6 +309,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ('lookup_val', models.IntegerField()),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326)),
+                ('group', models.ForeignKey(default=None, to='disasterinfosite.ShapefileGroup'))
             ],
         ),
         migrations.AddField(

--- a/disasterinfosite/migrations/0001_initial.py
+++ b/disasterinfosite/migrations/0001_initial.py
@@ -108,8 +108,8 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=50)),
                 ('display_name', models.CharField(max_length=50)),
                 ('order_of_appearance', models.IntegerField(help_text='The order, from left to right, in which you would like this group to appear, when applicable.', default=0)),
-                ('likely_scenario_title', models.CharField(max_length=80)),
-                ('likely_scenario_text', models.TextField()),
+                ('likely_scenario_title', models.CharField(max_length=80, blank=True)),
+                ('likely_scenario_text', models.TextField(blank=True)),
             ],
         ),
         migrations.CreateModel(

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -182,121 +182,121 @@ class ShapefileGroup(models.Model):
 # modelsClasses
 class EQ_Fault_Buffer(models.Model):
     def getGroup():
-        return ShapefileGroup.objects.get_or_create(name='foo')[0]
+        return ShapefileGroup.objects.get_or_create(name='q')[0]
 
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
 class EQ_Fault_Shaking(models.Model):
     def getGroup():
-        return ShapefileGroup.objects.get_or_create(name='foo')[0]
+        return ShapefileGroup.objects.get_or_create(name='q')[0]
 
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
 class EQ_Fault_Worst(models.Model):
     def getGroup():
-        return ShapefileGroup.objects.get_or_create(name='foo')[0]
+        return ShapefileGroup.objects.get_or_create(name='q')[0]
 
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
 class EQ_Historic_Distance(models.Model):
     def getGroup():
-        return ShapefileGroup.objects.get_or_create(name='foo')[0]
+        return ShapefileGroup.objects.get_or_create(name='q')[0]
 
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
 class Fire_Burn_Probability2(models.Model):
     def getGroup():
-        return ShapefileGroup.objects.get_or_create(name='bar')[0]
+        return ShapefileGroup.objects.get_or_create(name='f')[0]
 
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
 class Fire_Hist_Bound(models.Model):
     def getGroup():
-        return ShapefileGroup.objects.get_or_create(name='bar')[0]
+        return ShapefileGroup.objects.get_or_create(name='f')[0]
 
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
 class Fire_Worst_Case_ph2(models.Model):
     def getGroup():
-        return ShapefileGroup.objects.get_or_create(name='bar')[0]
+        return ShapefileGroup.objects.get_or_create(name='f')[0]
 
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
 class Flood_Channel_Migration_Zones(models.Model):
     def getGroup():
-        return ShapefileGroup.objects.get_or_create(name='baz')[0]
+        return ShapefileGroup.objects.get_or_create(name='w')[0]
 
     lookup_val = models.CharField(max_length=80)
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
 class Flood_FEMA_DFRIM_2015(models.Model):
     def getGroup():
-        return ShapefileGroup.objects.get_or_create(name='baz')[0]
+        return ShapefileGroup.objects.get_or_create(name='w')[0]
 
     lookup_val = models.CharField(max_length=80)
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
 class Flood_Worst_Case(models.Model):
     def getGroup():
-        return ShapefileGroup.objects.get_or_create(name='baz')[0]
+        return ShapefileGroup.objects.get_or_create(name='w')[0]
 
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
@@ -308,7 +308,7 @@ class Landslide_placeholder2(models.Model):
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
@@ -320,7 +320,7 @@ class summerstorm(models.Model):
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 
@@ -332,7 +332,7 @@ class winterstorm(models.Model):
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    group = models.ForeignKey(ShapefileGroup, default=getGroup)
     def __str__(self):
         return str(self.lookup_val)
 

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -458,79 +458,79 @@ class Snugget(models.Model):
         EQ_Fault_Buffer_rating = qs_EQ_Fault_Buffer.values_list('lookup_val', flat=True)
         for rating in EQ_Fault_Buffer_rating:
             individualSnugget = Snugget.objects.filter(EQ_Fault_Buffer_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_EQ_Fault_Shaking = EQ_Fault_Shaking.objects.filter(geom__contains=pnt)
         EQ_Fault_Shaking_rating = qs_EQ_Fault_Shaking.values_list('lookup_val', flat=True)
         for rating in EQ_Fault_Shaking_rating:
             individualSnugget = Snugget.objects.filter(EQ_Fault_Shaking_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_EQ_Fault_Worst = EQ_Fault_Worst.objects.filter(geom__contains=pnt)
         EQ_Fault_Worst_rating = qs_EQ_Fault_Worst.values_list('lookup_val', flat=True)
         for rating in EQ_Fault_Worst_rating:
             individualSnugget = Snugget.objects.filter(EQ_Fault_Worst_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_EQ_Historic_Distance = EQ_Historic_Distance.objects.filter(geom__contains=pnt)
         EQ_Historic_Distance_rating = qs_EQ_Historic_Distance.values_list('lookup_val', flat=True)
         for rating in EQ_Historic_Distance_rating:
             individualSnugget = Snugget.objects.filter(EQ_Historic_Distance_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_Fire_Burn_Probability2 = Fire_Burn_Probability2.objects.filter(geom__contains=pnt)
         Fire_Burn_Probability2_rating = qs_Fire_Burn_Probability2.values_list('lookup_val', flat=True)
         for rating in Fire_Burn_Probability2_rating:
             individualSnugget = Snugget.objects.filter(Fire_Burn_Probability2_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_Fire_Hist_Bound = Fire_Hist_Bound.objects.filter(geom__contains=pnt)
         Fire_Hist_Bound_rating = qs_Fire_Hist_Bound.values_list('lookup_val', flat=True)
         for rating in Fire_Hist_Bound_rating:
             individualSnugget = Snugget.objects.filter(Fire_Hist_Bound_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_Fire_Worst_Case_ph2 = Fire_Worst_Case_ph2.objects.filter(geom__contains=pnt)
         Fire_Worst_Case_ph2_rating = qs_Fire_Worst_Case_ph2.values_list('lookup_val', flat=True)
         for rating in Fire_Worst_Case_ph2_rating:
             individualSnugget = Snugget.objects.filter(Fire_Worst_Case_ph2_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_Flood_Channel_Migration_Zones = Flood_Channel_Migration_Zones.objects.filter(geom__contains=pnt)
         Flood_Channel_Migration_Zones_rating = qs_Flood_Channel_Migration_Zones.values_list('lookup_val', flat=True)
         for rating in Flood_Channel_Migration_Zones_rating:
             individualSnugget = Snugget.objects.filter(Flood_Channel_Migration_Zones_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_Flood_FEMA_DFRIM_2015 = Flood_FEMA_DFRIM_2015.objects.filter(geom__contains=pnt)
         Flood_FEMA_DFRIM_2015_rating = qs_Flood_FEMA_DFRIM_2015.values_list('lookup_val', flat=True)
         for rating in Flood_FEMA_DFRIM_2015_rating:
             individualSnugget = Snugget.objects.filter(Flood_FEMA_DFRIM_2015_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_Flood_Worst_Case = Flood_Worst_Case.objects.filter(geom__contains=pnt)
         Flood_Worst_Case_rating = qs_Flood_Worst_Case.values_list('lookup_val', flat=True)
         for rating in Flood_Worst_Case_rating:
             individualSnugget = Snugget.objects.filter(Flood_Worst_Case_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_Landslide_placeholder2 = Landslide_placeholder2.objects.filter(geom__contains=pnt)
         Landslide_placeholder2_rating = qs_Landslide_placeholder2.values_list('lookup_val', flat=True)
         for rating in Landslide_placeholder2_rating:
             individualSnugget = Snugget.objects.filter(Landslide_placeholder2_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_summerstorm = summerstorm.objects.filter(geom__contains=pnt)
         summerstorm_rating = qs_summerstorm.values_list('lookup_val', flat=True)
         for rating in summerstorm_rating:
             individualSnugget = Snugget.objects.filter(summerstorm_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
         qs_winterstorm = winterstorm.objects.filter(geom__contains=pnt)
         winterstorm_rating = qs_winterstorm.values_list('lookup_val', flat=True)
         for rating in winterstorm_rating:
             individualSnugget = Snugget.objects.filter(winterstorm_filter__lookup_val__exact=rating).select_subclasses()
-            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)
 
 
         return {'groups': groupsDict,

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -97,19 +97,19 @@ class Location(SingletonModel):
     # GENERATED CODE GOES HERE
     # DO NOT MANUALLY EDIT CODE IN THIS SECTION - IT WILL BE OVERWRITTEN
     # locationsList
-            'Fire_Burn_Probability2': Fire_Burn_Probability2.objects.data_bounds(),
-            'Flood_Worst_Case': Flood_Worst_Case.objects.data_bounds(),
             'EQ_Fault_Buffer': EQ_Fault_Buffer.objects.data_bounds(),
-            'Fire_Worst_Case_ph2': Fire_Worst_Case_ph2.objects.data_bounds(),
+            'EQ_Fault_Shaking': EQ_Fault_Shaking.objects.data_bounds(),
             'EQ_Fault_Worst': EQ_Fault_Worst.objects.data_bounds(),
             'EQ_Historic_Distance': EQ_Historic_Distance.objects.data_bounds(),
-            'EQ_Fault_Shaking': EQ_Fault_Shaking.objects.data_bounds(),
-            'Flood_FEMA_DFRIM_2015': Flood_FEMA_DFRIM_2015.objects.data_bounds(),
+            'Fire_Burn_Probability2': Fire_Burn_Probability2.objects.data_bounds(),
             'Fire_Hist_Bound': Fire_Hist_Bound.objects.data_bounds(),
-            'winterstorm': winterstorm.objects.data_bounds(),
-            'summerstorm': summerstorm.objects.data_bounds(),
+            'Fire_Worst_Case_ph2': Fire_Worst_Case_ph2.objects.data_bounds(),
+            'Flood_Channel_Migration_Zones': Flood_Channel_Migration_Zones.objects.data_bounds(),
+            'Flood_FEMA_DFRIM_2015': Flood_FEMA_DFRIM_2015.objects.data_bounds(),
+            'Flood_Worst_Case': Flood_Worst_Case.objects.data_bounds(),
             'Landslide_placeholder2': Landslide_placeholder2.objects.data_bounds(),
-            'Flood_Channel_Migration_Zones': Flood_Channel_Migration_Zones.objects.data_bounds()
+            'summerstorm': summerstorm.objects.data_bounds(),
+            'winterstorm': winterstorm.objects.data_bounds()
     # END OF GENERATED CODE BLOCK
     ######################################################
         }
@@ -163,111 +163,176 @@ class ShapeManager(models.GeoManager):
     def data_bounds(self):
         return self.aggregate(Extent('geom'))['geom__extent']
 
+class ShapefileGroup(models.Model):
+    name = models.CharField(max_length=50)
+    display_name = models.CharField(max_length=50)
+    order_of_appearance = models.IntegerField(
+        default=0,
+        help_text="The order, from left to right, in which you would like this group to appear, when applicable."
+    )
+    likely_scenario_title = models.CharField(max_length=80)
+    likely_scenario_text = models.TextField()
+
+    def __str__(self):
+        return self.name
+
 ######################################################
 # GENERATED CODE GOES HERE
 # DO NOT MANUALLY EDIT CODE IN THIS SECTION - IT WILL BE OVERWRITTEN
 # modelsClasses
-class Fire_Burn_Probability2(models.Model):
-    lookup_val = models.IntegerField()
-    geom = models.MultiPolygonField(srid=4326)
-    objects = ShapeManager()
-
-    def __str__(self):
-        return str(self.lookup_val)
-
-class Flood_Worst_Case(models.Model):
-    lookup_val = models.IntegerField()
-    geom = models.MultiPolygonField(srid=4326)
-    objects = ShapeManager()
-
-    def __str__(self):
-        return str(self.lookup_val)
-
 class EQ_Fault_Buffer(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='foo')[0]
+
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    def __str__(self):
-        return str(self.lookup_val)
-
-class Fire_Worst_Case_ph2(models.Model):
-    lookup_val = models.IntegerField()
-    geom = models.MultiPolygonField(srid=4326)
-    objects = ShapeManager()
-
-    def __str__(self):
-        return str(self.lookup_val)
-
-class EQ_Fault_Worst(models.Model):
-    lookup_val = models.IntegerField()
-    geom = models.MultiPolygonField(srid=4326)
-    objects = ShapeManager()
-
-    def __str__(self):
-        return str(self.lookup_val)
-
-class EQ_Historic_Distance(models.Model):
-    lookup_val = models.IntegerField()
-    geom = models.MultiPolygonField(srid=4326)
-    objects = ShapeManager()
-
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
     def __str__(self):
         return str(self.lookup_val)
 
 class EQ_Fault_Shaking(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='foo')[0]
+
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
     def __str__(self):
         return str(self.lookup_val)
 
-class Flood_FEMA_DFRIM_2015(models.Model):
-    lookup_val = models.CharField(max_length=80)
+class EQ_Fault_Worst(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='foo')[0]
+
+    lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    def __str__(self):
+        return str(self.lookup_val)
+
+class EQ_Historic_Distance(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='foo')[0]
+
+    lookup_val = models.IntegerField()
+    geom = models.MultiPolygonField(srid=4326)
+    objects = ShapeManager()
+
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    def __str__(self):
+        return str(self.lookup_val)
+
+class Fire_Burn_Probability2(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='bar')[0]
+
+    lookup_val = models.IntegerField()
+    geom = models.MultiPolygonField(srid=4326)
+    objects = ShapeManager()
+
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
     def __str__(self):
         return str(self.lookup_val)
 
 class Fire_Hist_Bound(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='bar')[0]
+
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
     def __str__(self):
         return str(self.lookup_val)
 
-class winterstorm(models.Model):
+class Fire_Worst_Case_ph2(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='bar')[0]
+
     lookup_val = models.IntegerField()
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
-    def __str__(self):
-        return str(self.lookup_val)
-
-class summerstorm(models.Model):
-    lookup_val = models.IntegerField()
-    geom = models.MultiPolygonField(srid=4326)
-    objects = ShapeManager()
-
-    def __str__(self):
-        return str(self.lookup_val)
-
-class Landslide_placeholder2(models.Model):
-    lookup_val = models.FloatField()
-    geom = models.MultiPolygonField(srid=4326)
-    objects = ShapeManager()
-
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
     def __str__(self):
         return str(self.lookup_val)
 
 class Flood_Channel_Migration_Zones(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='baz')[0]
+
     lookup_val = models.CharField(max_length=80)
     geom = models.MultiPolygonField(srid=4326)
     objects = ShapeManager()
 
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    def __str__(self):
+        return str(self.lookup_val)
+
+class Flood_FEMA_DFRIM_2015(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='baz')[0]
+
+    lookup_val = models.CharField(max_length=80)
+    geom = models.MultiPolygonField(srid=4326)
+    objects = ShapeManager()
+
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    def __str__(self):
+        return str(self.lookup_val)
+
+class Flood_Worst_Case(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='baz')[0]
+
+    lookup_val = models.IntegerField()
+    geom = models.MultiPolygonField(srid=4326)
+    objects = ShapeManager()
+
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    def __str__(self):
+        return str(self.lookup_val)
+
+class Landslide_placeholder2(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='Landslide_placeholder2')[0]
+
+    lookup_val = models.FloatField()
+    geom = models.MultiPolygonField(srid=4326)
+    objects = ShapeManager()
+
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    def __str__(self):
+        return str(self.lookup_val)
+
+class summerstorm(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='summerstorm')[0]
+
+    lookup_val = models.IntegerField()
+    geom = models.MultiPolygonField(srid=4326)
+    objects = ShapeManager()
+
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
+    def __str__(self):
+        return str(self.lookup_val)
+
+class winterstorm(models.Model):
+    def getGroup():
+        return ShapefileGroup.objects.get_or_create(name='winterstorm')[0]
+
+    lookup_val = models.IntegerField()
+    geom = models.MultiPolygonField(srid=4326)
+    objects = ShapeManager()
+
+    group = models.ForeignKey(ShapefileGroup, default=getGroup())
     def __str__(self):
         return str(self.lookup_val)
 
@@ -322,10 +387,9 @@ class SnuggetType(models.Model):
     def __str__(self):
         return self.name
 
-
 class SnuggetSection(models.Model):
     name = models.CharField(max_length=50)
-    order = models.IntegerField(
+    order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the tab. 0 is at the top."
     )
@@ -336,7 +400,7 @@ class SnuggetSection(models.Model):
 
 class SnuggetSubSection(models.Model):
     name = models.CharField(max_length=50)
-    order = models.IntegerField(
+    order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the section. 0 is at the top. These can be in different sections or mutually exclusive, hence the non-unique values."
     )
@@ -352,24 +416,25 @@ class Snugget(models.Model):
 # GENERATED CODE GOES HERE
 # DO NOT MANUALLY EDIT CODE IN THIS SECTION - IT WILL BE OVERWRITTEN
 # modelsFilters
-    Fire_Burn_Probability2_filter = models.ForeignKey(Fire_Burn_Probability2, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
-    Flood_Worst_Case_filter = models.ForeignKey(Flood_Worst_Case, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
     EQ_Fault_Buffer_filter = models.ForeignKey(EQ_Fault_Buffer, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
-    Fire_Worst_Case_ph2_filter = models.ForeignKey(Fire_Worst_Case_ph2, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
+    EQ_Fault_Shaking_filter = models.ForeignKey(EQ_Fault_Shaking, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
     EQ_Fault_Worst_filter = models.ForeignKey(EQ_Fault_Worst, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
     EQ_Historic_Distance_filter = models.ForeignKey(EQ_Historic_Distance, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
-    EQ_Fault_Shaking_filter = models.ForeignKey(EQ_Fault_Shaking, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
-    Flood_FEMA_DFRIM_2015_filter = models.ForeignKey(Flood_FEMA_DFRIM_2015, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
+    Fire_Burn_Probability2_filter = models.ForeignKey(Fire_Burn_Probability2, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
     Fire_Hist_Bound_filter = models.ForeignKey(Fire_Hist_Bound, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
-    winterstorm_filter = models.ForeignKey(winterstorm, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
-    summerstorm_filter = models.ForeignKey(summerstorm, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
-    Landslide_placeholder2_filter = models.ForeignKey(Landslide_placeholder2, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
+    Fire_Worst_Case_ph2_filter = models.ForeignKey(Fire_Worst_Case_ph2, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
     Flood_Channel_Migration_Zones_filter = models.ForeignKey(Flood_Channel_Migration_Zones, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
+    Flood_FEMA_DFRIM_2015_filter = models.ForeignKey(Flood_FEMA_DFRIM_2015, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
+    Flood_Worst_Case_filter = models.ForeignKey(Flood_Worst_Case, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
+    Landslide_placeholder2_filter = models.ForeignKey(Landslide_placeholder2, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
+    summerstorm_filter = models.ForeignKey(summerstorm, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
+    winterstorm_filter = models.ForeignKey(winterstorm, related_name='+', on_delete=models.PROTECT, blank=True, null=True)
 # END OF GENERATED CODE BLOCK
 ######################################################
 
     section = models.ForeignKey(SnuggetSection, related_name='+', on_delete=models.PROTECT)
     sub_section = models.ForeignKey(SnuggetSubSection, related_name='+', on_delete=models.PROTECT, null=True, blank=True)
+    group = models.ForeignKey(ShapefileGroup, on_delete=models.PROTECT, null=True)
 
     def getRelatedTemplate(self):
         return "snugget.html"
@@ -377,6 +442,11 @@ class Snugget(models.Model):
     @staticmethod
     def findSnuggetsForPoint(lat=0, lng=0, merge_deform = True):
         pnt = Point(lng, lat)
+        groups = ShapefileGroup.objects.all()
+        groupsDict = {}
+
+        for group in groups:
+            groupsDict[group.name] = []
 
 
 
@@ -384,114 +454,99 @@ class Snugget(models.Model):
 # GENERATED CODE GOES HERE
 # DO NOT MANUALLY EDIT CODE IN THIS SECTION - IT WILL BE OVERWRITTEN
 # modelsGeoFilters
-
-        fire_snuggets = []
-        flood_snuggets = []
-        quake_snuggets = []
-        winterstorm_snuggets = []
-        summerstorm_snuggets = []
-        Landslide_placeholder2_snuggets = []
-
-        qs_Fire_Burn_Probability2 = Fire_Burn_Probability2.objects.filter(geom__contains=pnt)
-        Fire_Burn_Probability2_rating = qs_Fire_Burn_Probability2.values_list('lookup_val', flat=True)
-        for rating in Fire_Burn_Probability2_rating:
-            individualSnugget = Snugget.objects.filter(Fire_Burn_Probability2_filter__lookup_val__exact=rating).select_subclasses()
-            fire_snuggets.extend(individualSnugget)
-
-        qs_Flood_Worst_Case = Flood_Worst_Case.objects.filter(geom__contains=pnt)
-        Flood_Worst_Case_rating = qs_Flood_Worst_Case.values_list('lookup_val', flat=True)
-        for rating in Flood_Worst_Case_rating:
-            individualSnugget = Snugget.objects.filter(Flood_Worst_Case_filter__lookup_val__exact=rating).select_subclasses()
-            flood_snuggets.extend(individualSnugget)
-
         qs_EQ_Fault_Buffer = EQ_Fault_Buffer.objects.filter(geom__contains=pnt)
         EQ_Fault_Buffer_rating = qs_EQ_Fault_Buffer.values_list('lookup_val', flat=True)
         for rating in EQ_Fault_Buffer_rating:
             individualSnugget = Snugget.objects.filter(EQ_Fault_Buffer_filter__lookup_val__exact=rating).select_subclasses()
-            quake_snuggets.extend(individualSnugget)
-
-        qs_Fire_Worst_Case_ph2 = Fire_Worst_Case_ph2.objects.filter(geom__contains=pnt)
-        Fire_Worst_Case_ph2_rating = qs_Fire_Worst_Case_ph2.values_list('lookup_val', flat=True)
-        for rating in Fire_Worst_Case_ph2_rating:
-            individualSnugget = Snugget.objects.filter(Fire_Worst_Case_ph2_filter__lookup_val__exact=rating).select_subclasses()
-            fire_snuggets.extend(individualSnugget)
-
-        qs_EQ_Fault_Worst = EQ_Fault_Worst.objects.filter(geom__contains=pnt)
-        EQ_Fault_Worst_rating = qs_EQ_Fault_Worst.values_list('lookup_val', flat=True)
-        for rating in EQ_Fault_Worst_rating:
-            individualSnugget = Snugget.objects.filter(EQ_Fault_Worst_filter__lookup_val__exact=rating).select_subclasses()
-            quake_snuggets.extend(individualSnugget)
-
-        qs_EQ_Historic_Distance = EQ_Historic_Distance.objects.filter(geom__contains=pnt)
-        EQ_Historic_Distance_rating = qs_EQ_Historic_Distance.values_list('lookup_val', flat=True)
-        for rating in EQ_Historic_Distance_rating:
-            individualSnugget = Snugget.objects.filter(EQ_Historic_Distance_filter__lookup_val__exact=rating).select_subclasses()
-            quake_snuggets.extend(individualSnugget)
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
 
         qs_EQ_Fault_Shaking = EQ_Fault_Shaking.objects.filter(geom__contains=pnt)
         EQ_Fault_Shaking_rating = qs_EQ_Fault_Shaking.values_list('lookup_val', flat=True)
         for rating in EQ_Fault_Shaking_rating:
             individualSnugget = Snugget.objects.filter(EQ_Fault_Shaking_filter__lookup_val__exact=rating).select_subclasses()
-            quake_snuggets.extend(individualSnugget)
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
 
-        qs_Flood_FEMA_DFRIM_2015 = Flood_FEMA_DFRIM_2015.objects.filter(geom__contains=pnt)
-        Flood_FEMA_DFRIM_2015_rating = qs_Flood_FEMA_DFRIM_2015.values_list('lookup_val', flat=True)
-        for rating in Flood_FEMA_DFRIM_2015_rating:
-            individualSnugget = Snugget.objects.filter(Flood_FEMA_DFRIM_2015_filter__lookup_val__exact=rating).select_subclasses()
-            flood_snuggets.extend(individualSnugget)
+        qs_EQ_Fault_Worst = EQ_Fault_Worst.objects.filter(geom__contains=pnt)
+        EQ_Fault_Worst_rating = qs_EQ_Fault_Worst.values_list('lookup_val', flat=True)
+        for rating in EQ_Fault_Worst_rating:
+            individualSnugget = Snugget.objects.filter(EQ_Fault_Worst_filter__lookup_val__exact=rating).select_subclasses()
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+
+        qs_EQ_Historic_Distance = EQ_Historic_Distance.objects.filter(geom__contains=pnt)
+        EQ_Historic_Distance_rating = qs_EQ_Historic_Distance.values_list('lookup_val', flat=True)
+        for rating in EQ_Historic_Distance_rating:
+            individualSnugget = Snugget.objects.filter(EQ_Historic_Distance_filter__lookup_val__exact=rating).select_subclasses()
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+
+        qs_Fire_Burn_Probability2 = Fire_Burn_Probability2.objects.filter(geom__contains=pnt)
+        Fire_Burn_Probability2_rating = qs_Fire_Burn_Probability2.values_list('lookup_val', flat=True)
+        for rating in Fire_Burn_Probability2_rating:
+            individualSnugget = Snugget.objects.filter(Fire_Burn_Probability2_filter__lookup_val__exact=rating).select_subclasses()
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
 
         qs_Fire_Hist_Bound = Fire_Hist_Bound.objects.filter(geom__contains=pnt)
         Fire_Hist_Bound_rating = qs_Fire_Hist_Bound.values_list('lookup_val', flat=True)
         for rating in Fire_Hist_Bound_rating:
             individualSnugget = Snugget.objects.filter(Fire_Hist_Bound_filter__lookup_val__exact=rating).select_subclasses()
-            fire_snuggets.extend(individualSnugget)
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
 
-        qs_winterstorm = winterstorm.objects.filter(geom__contains=pnt)
-        winterstorm_rating = qs_winterstorm.values_list('lookup_val', flat=True)
-        for rating in winterstorm_rating:
-            individualSnugget = Snugget.objects.filter(winterstorm_filter__lookup_val__exact=rating).select_subclasses()
-            winterstorm_snuggets.extend(individualSnugget)
-
-        qs_summerstorm = summerstorm.objects.filter(geom__contains=pnt)
-        summerstorm_rating = qs_summerstorm.values_list('lookup_val', flat=True)
-        for rating in summerstorm_rating:
-            individualSnugget = Snugget.objects.filter(summerstorm_filter__lookup_val__exact=rating).select_subclasses()
-            summerstorm_snuggets.extend(individualSnugget)
-
-        qs_Landslide_placeholder2 = Landslide_placeholder2.objects.filter(geom__contains=pnt)
-        Landslide_placeholder2_rating = qs_Landslide_placeholder2.values_list('lookup_val', flat=True)
-        for rating in Landslide_placeholder2_rating:
-            individualSnugget = Snugget.objects.filter(Landslide_placeholder2_filter__lookup_val__exact=rating).select_subclasses()
-            Landslide_placeholder2_snuggets.extend(individualSnugget)
+        qs_Fire_Worst_Case_ph2 = Fire_Worst_Case_ph2.objects.filter(geom__contains=pnt)
+        Fire_Worst_Case_ph2_rating = qs_Fire_Worst_Case_ph2.values_list('lookup_val', flat=True)
+        for rating in Fire_Worst_Case_ph2_rating:
+            individualSnugget = Snugget.objects.filter(Fire_Worst_Case_ph2_filter__lookup_val__exact=rating).select_subclasses()
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
 
         qs_Flood_Channel_Migration_Zones = Flood_Channel_Migration_Zones.objects.filter(geom__contains=pnt)
         Flood_Channel_Migration_Zones_rating = qs_Flood_Channel_Migration_Zones.values_list('lookup_val', flat=True)
         for rating in Flood_Channel_Migration_Zones_rating:
             individualSnugget = Snugget.objects.filter(Flood_Channel_Migration_Zones_filter__lookup_val__exact=rating).select_subclasses()
-            flood_snuggets.extend(individualSnugget)
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+
+        qs_Flood_FEMA_DFRIM_2015 = Flood_FEMA_DFRIM_2015.objects.filter(geom__contains=pnt)
+        Flood_FEMA_DFRIM_2015_rating = qs_Flood_FEMA_DFRIM_2015.values_list('lookup_val', flat=True)
+        for rating in Flood_FEMA_DFRIM_2015_rating:
+            individualSnugget = Snugget.objects.filter(Flood_FEMA_DFRIM_2015_filter__lookup_val__exact=rating).select_subclasses()
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+
+        qs_Flood_Worst_Case = Flood_Worst_Case.objects.filter(geom__contains=pnt)
+        Flood_Worst_Case_rating = qs_Flood_Worst_Case.values_list('lookup_val', flat=True)
+        for rating in Flood_Worst_Case_rating:
+            individualSnugget = Snugget.objects.filter(Flood_Worst_Case_filter__lookup_val__exact=rating).select_subclasses()
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+
+        qs_Landslide_placeholder2 = Landslide_placeholder2.objects.filter(geom__contains=pnt)
+        Landslide_placeholder2_rating = qs_Landslide_placeholder2.values_list('lookup_val', flat=True)
+        for rating in Landslide_placeholder2_rating:
+            individualSnugget = Snugget.objects.filter(Landslide_placeholder2_filter__lookup_val__exact=rating).select_subclasses()
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+
+        qs_summerstorm = summerstorm.objects.filter(geom__contains=pnt)
+        summerstorm_rating = qs_summerstorm.values_list('lookup_val', flat=True)
+        for rating in summerstorm_rating:
+            individualSnugget = Snugget.objects.filter(summerstorm_filter__lookup_val__exact=rating).select_subclasses()
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
+
+        qs_winterstorm = winterstorm.objects.filter(geom__contains=pnt)
+        winterstorm_rating = qs_winterstorm.values_list('lookup_val', flat=True)
+        for rating in winterstorm_rating:
+            individualSnugget = Snugget.objects.filter(winterstorm_filter__lookup_val__exact=rating).select_subclasses()
+            groupsDict[individualSnugget.group.name].extend(individualSnugget)
 
 
-        return {'groups': {
-                          'fire_snugs': fire_snuggets,
-                          'flood_snugs': flood_snuggets,
-                          'quake_snugs': quake_snuggets,
-                          'winterstorm_snugs': winterstorm_snuggets,
-                          'summerstorm_snugs': summerstorm_snuggets,
-                          'Landslide_placeholder2_snugs': Landslide_placeholder2_snuggets
-                          },
-                'Fire_Burn_Probability2_rating': Fire_Burn_Probability2_rating,
-                'Flood_Worst_Case_rating': Flood_Worst_Case_rating,
+        return {'groups': groupsDict,
                 'EQ_Fault_Buffer_rating': EQ_Fault_Buffer_rating,
-                'Fire_Worst_Case_ph2_rating': Fire_Worst_Case_ph2_rating,
+                'EQ_Fault_Shaking_rating': EQ_Fault_Shaking_rating,
                 'EQ_Fault_Worst_rating': EQ_Fault_Worst_rating,
                 'EQ_Historic_Distance_rating': EQ_Historic_Distance_rating,
-                'EQ_Fault_Shaking_rating': EQ_Fault_Shaking_rating,
-                'Flood_FEMA_DFRIM_2015_rating': Flood_FEMA_DFRIM_2015_rating,
+                'Fire_Burn_Probability2_rating': Fire_Burn_Probability2_rating,
                 'Fire_Hist_Bound_rating': Fire_Hist_Bound_rating,
-                'winterstorm_rating': winterstorm_rating,
-                'summerstorm_rating': summerstorm_rating,
+                'Fire_Worst_Case_ph2_rating': Fire_Worst_Case_ph2_rating,
+                'Flood_Channel_Migration_Zones_rating': Flood_Channel_Migration_Zones_rating,
+                'Flood_FEMA_DFRIM_2015_rating': Flood_FEMA_DFRIM_2015_rating,
+                'Flood_Worst_Case_rating': Flood_Worst_Case_rating,
                 'Landslide_placeholder2_rating': Landslide_placeholder2_rating,
-                'Flood_Channel_Migration_Zones_rating': Flood_Channel_Migration_Zones_rating
+                'summerstorm_rating': summerstorm_rating,
+                'winterstorm_rating': winterstorm_rating
                 }
 # END OF GENERATED CODE BLOCK
 ######################################################
@@ -504,7 +559,7 @@ class Snugget(models.Model):
 class TextSnugget(Snugget):
     name = SNUGGET_TYPES[SNUG_TEXT]
     content = models.TextField()
-    heading = models.TextField(default="")
+    # is now group.display_name heading = models.TextField(default="")
     image = models.TextField(default="")
     percentage = models.FloatField(null=True)
 
@@ -525,7 +580,7 @@ class EmbedSnugget(Snugget):
         return "Embed Snugget: " + str(self.embed)
 
 class PastEventsPhoto(models.Model):
-    heading = models.CharField(default="", max_length=50)
+    group = models.ForeignKey(ShapefileGroup, on_delete=models.PROTECT, null=True)
     image = models.ImageField(upload_to="photos")
 
     def __str__(self):

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -170,8 +170,8 @@ class ShapefileGroup(models.Model):
         default=0,
         help_text="The order, from left to right, in which you would like this group to appear, when applicable."
     )
-    likely_scenario_title = models.CharField(max_length=80)
-    likely_scenario_text = models.TextField()
+    likely_scenario_title = models.CharField(max_length=80, blank=True)
+    likely_scenario_text = models.TextField(blank=True)
 
     def __str__(self):
         return self.name

--- a/import.py
+++ b/import.py
@@ -285,7 +285,7 @@ def modelClassGen(stem, sf, keyField, srs, shapeType, shapefileGroup):
   text += "    " + keyField.lower() + " = models." + findFieldType(sf, keyField) + "\n"
   text += "    geom = models." + shapeType + "Field(srid=" + srs + ")\n"
   text += "    objects = ShapeManager()\n\n"
-  text += "    group = models.ForeignKey(ShapefileGroup, default=getGroup())\n"
+  text += "    group = models.ForeignKey(ShapefileGroup, default=getGroup)\n"
   text += "    def __str__(self):\n"
   text += "        return str(self." + keyField.lower() + ")\n\n"
 

--- a/import.py
+++ b/import.py
@@ -298,7 +298,7 @@ def modelsGeoFilterGen(stem, keyField):
   text += "        " + stem + "_rating = " + "qs_" + stem + ".values_list('" + keyField.lower() + "', flat=True)\n"
   text += "        for rating in " + stem + "_rating:\n"
   text += "            individualSnugget = Snugget.objects.filter(" + stem + "_filter__" + keyField.lower() + "__exact=rating).select_subclasses()\n"
-  text += "            groupsDict[individualSnugget.group.name].extend(individualSnugget)\n\n"
+  text += "            groupsDict[individualSnugget[0].group.name].extend(individualSnugget)\n\n"
   return text
 
 


### PR DESCRIPTION
I did it here because it was easier to wrap my brain around it in MissoulaReady because the data provides a concrete example. Now that I know what to do, I can take it up to disaster-preparedness and down to seattle-ready.

This exposes the ordering of the tabs and the likely scenarios in DjangoAdmin. It also puts snuggets in tab groups based on their shapefile, which makes the 'heading' column in snuggets.csv optional.

This will be more resilient to import failures and general silly errors caused by a typo or forgetting that I said 'fire' and not 'wildfire' somewhere.
