### PR TITLE
Improvements for show_snugget

### DIFF
--- a/disasterinfosite/settings.py
+++ b/disasterinfosite/settings.py
@@ -16,12 +16,12 @@ SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 if DEBUG:
     ALLOWED_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0']
 else:
-# hazardready.org is the current production server. 23.92.25.126 is its numeric address. eldang.eldan.co.uk is our demo/test server  
+# hazardready.org is the current production server. 23.92.25.126 is its numeric address. eldang.eldan.co.uk is our demo/test server
     ALLOWED_HOSTS = ['hazardready.org', '.hazardready.org', '23.92.25.126', 'eldang.eldan.co.uk']
 
 # Application definition

--- a/disasterinfosite/settings.py
+++ b/disasterinfosite/settings.py
@@ -16,12 +16,12 @@ SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 if DEBUG:
     ALLOWED_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0']
 else:
-# hazardready.org is the current production server. 23.92.25.126 is its numeric address. eldang.eldan.co.uk is our demo/test server
+# hazardready.org is the current production server. 23.92.25.126 is its numeric address. eldang.eldan.co.uk is our demo/test server  
     ALLOWED_HOSTS = ['hazardready.org', '.hazardready.org', '23.92.25.126', 'eldang.eldan.co.uk']
 
 # Application definition

--- a/disasterinfosite/templatetags/show_snugget.py
+++ b/disasterinfosite/templatetags/show_snugget.py
@@ -25,16 +25,14 @@ class SnuggetNode(template.Node):
         except (template.base.VariableDoesNotExist):
             return ''
 
+        from django.template.loader import get_template, select_template
         from django.utils.itercompat import is_iterable
         if isinstance(file_name, template.Template):
             t = file_name
-        elif isinstance(getattr(file_name, 'template', None), template.Template):
-            t = file_name.template
         elif not isinstance(file_name, six.string_types) and is_iterable(file_name):
-            t = context.template.engine.select_template(file_name)
+            t = select_template(file_name)
         else:
-            t = context.template.engine.get_template(file_name)
-        context.render_context[self] = t
+            t = get_template(file_name)
         return t.render(context)
 
     @classmethod

--- a/disasterinfosite/templatetags/show_snugget.py
+++ b/disasterinfosite/templatetags/show_snugget.py
@@ -15,8 +15,8 @@ class SnuggetNode(template.Node):
         template object in render_context to avoid reparsing and
         loading when used in a for loop.
 
-        A lot of this is token from django.template.base's InclusionNode.
-        This behavior should be changed if we upgrade to Django 1.8.
+        A lot of this is token from django.template.base's InclusionNode, for Django 1.8.6.
+        Upgrading Django should mean updating this to match.
         """
         try:
             snugget = self.snugget.resolve(context)
@@ -34,15 +34,6 @@ class SnuggetNode(template.Node):
         else:
             t = get_template(file_name)
         return t.render(context)
-
-    def get_resolved_arguments(self, context):
-        """
-        This function is also snipped from django.template.base.
-        """
-        resolved_args = [var.resolve(context) for var in self.args]
-        resolved_args = [context] + resolved_args
-        resolved_kwargs = {k: v.resolve(context) for k, v in self.kwargs.items()}
-        return resolved_args, resolved_kwargs
 
     @classmethod
     def handle_token(cls, parser, token):

--- a/disasterinfosite/templatetags/show_snugget.py
+++ b/disasterinfosite/templatetags/show_snugget.py
@@ -15,7 +15,7 @@ class SnuggetNode(template.Node):
         template object in render_context to avoid reparsing and
         loading when used in a for loop.
 
-        A lot of this is token from django.template.base's InclusionNode, for Django 1.8.6.
+        A lot of this is taken from django.template.base's InclusionNode, for Django 1.8.6.
         Upgrading Django should mean updating this to match.
         """
         try:

--- a/disasterinfosite/templatetags/show_snugget.py
+++ b/disasterinfosite/templatetags/show_snugget.py
@@ -25,14 +25,16 @@ class SnuggetNode(template.Node):
         except (template.base.VariableDoesNotExist):
             return ''
 
-        from django.template.loader import get_template, select_template
         from django.utils.itercompat import is_iterable
         if isinstance(file_name, template.Template):
             t = file_name
+        elif isinstance(getattr(file_name, 'template', None), template.Template):
+            t = file_name.template
         elif not isinstance(file_name, six.string_types) and is_iterable(file_name):
-            t = select_template(file_name)
+            t = context.template.engine.select_template(file_name)
         else:
-            t = get_template(file_name)
+            t = context.template.engine.get_template(file_name)
+        context.render_context[self] = t
         return t.render(context)
 
     @classmethod


### PR DESCRIPTION
There was a comment in this template tag that made me go 'hmmmm', so I looked into it a little more. It turns out that part of this function is grabbed from inside Django to choose between the type of snugget to render (did you know that there is such a thing as an 'image snugget' and maybe we want to investigate that a little more).

So I got rid of some code that it was never using anyhow, and updated the borrowed code to match what's in Django.
