### PR TITLE
Just remove the sourcemap reference, life is too short

### DIFF
--- a/disasterinfosite/static/css/foundation.css
+++ b/disasterinfosite/static/css/foundation.css
@@ -5665,4 +5665,3 @@ html.is-reveal-open {
 .is-stuck .hide-for-sticky {
   display: none; }
 
-/*# sourceMappingURL=foundation.css.map */


### PR DESCRIPTION
`collectstatic` is desperate to find this thing for a css file we have no control over and will not be using in the future anyway.