### PR TITLE
This is now Montana Ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Missoula Ready
+# Montana Ready
 
 The project is a custom instance of the [Disaster Preparedness](https://github.com/missoula-ready/disaster-preparedness) project, which is an adaptation of [a pioneering project from Oregon](https://github.com/Oregon-Public-Broadcasting/earthquake-preparedness) but has been generalized to make it easy to clone and tailor to other regions.
 

--- a/disasterinfosite/settings.py
+++ b/disasterinfosite/settings.py
@@ -156,8 +156,8 @@ else:
     # So for our current test server,
     # testing.hazardready.org/region/ , we need:
     # STATIC_URL = '/region/static/'
-    FORCE_SCRIPT_NAME = '/missoula/'
-    STATIC_URL = '/missoula/static/'
+    FORCE_SCRIPT_NAME = '/montana/'
+    STATIC_URL = '/montana/static/'
 
 WHITENOISE_STATIC_PREFIX = '/static/'
 STORAGES = {
@@ -178,4 +178,4 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media', 'img')
 if DEBUG:
     MEDIA_URL = '/media/img/'
 else:
-    MEDIA_URL = '/missoula/static/img/'
+    MEDIA_URL = '/montana/static/img/'


### PR DESCRIPTION
- it has 'montana' in the URL instead of 'missoula'
- user-facing text will say "Montana", not "Missoula"